### PR TITLE
Add minimal Burp-style exploit server utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# blablasdvkj
-/xvx
+# Minimal Exploit Server (Burp-style workflow)
+
+This repository contains a lightweight Python exploit-server-like utility for **authorized security testing labs**.
+
+## Features
+
+- Serves a configurable exploit response at `/`
+- Stores request captures for inspection at `/admin/logs`
+- Serves payload files from `payloads/` at `/payload/<filename>`
+- Lets you update the root exploit body via `POST /admin/set-exploit` with an API token
+
+## Run
+
+```bash
+python3 exploit_server.py --host 0.0.0.0 --port 8000
+```
+
+Optional flags:
+
+- `--payload-dir payloads`
+- `--api-token <token>` (or env var `EXPLOIT_SERVER_TOKEN`)
+
+## Example usage
+
+1. Start server.
+2. Visit `http://localhost:8000/` (victim/test browser in your lab).
+3. Update exploit body:
+
+```bash
+curl -X POST http://localhost:8000/admin/set-exploit \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Token: <TOKEN>' \
+  -d '{"body":"<script src=\"/payload/hello.js\"></script>"}'
+```
+
+4. Review captures at:
+
+```bash
+curl http://localhost:8000/admin/logs
+```
+
+## Notes
+
+Use only on systems you own or are explicitly authorized to test.

--- a/exploit_server.py
+++ b/exploit_server.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Minimal exploit-server-like utility for local security testing labs.
+
+Features inspired by Burp Suite's exploit server workflow:
+- Host a configurable exploit response at `/`
+- Capture incoming requests for quick inspection
+- Serve payload files from a local directory at `/payload/<file>`
+- Update exploit content via authenticated local API
+
+This tool is intended for authorized testing environments only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import secrets
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+
+@dataclass
+class RequestRecord:
+    time: str
+    method: str
+    path: str
+    client: str
+    headers: dict[str, str]
+    body: str
+
+
+@dataclass
+class AppState:
+    exploit_body: str
+    payload_dir: Path
+    api_token: str
+    logs: list[RequestRecord] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def add_log(self, record: RequestRecord) -> None:
+        with self.lock:
+            self.logs.append(record)
+            # Keep memory bounded.
+            if len(self.logs) > 500:
+                self.logs[:] = self.logs[-500:]
+
+    def snapshot_logs(self) -> list[RequestRecord]:
+        with self.lock:
+            return list(self.logs)
+
+
+class ExploitHandler(BaseHTTPRequestHandler):
+    server_version = "ExploitServer/1.0"
+
+    @property
+    def app_state(self) -> AppState:
+        return self.server.app_state  # type: ignore[attr-defined]
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/":
+            self._capture_request(parsed)
+            self._write_html(self.app_state.exploit_body)
+            return
+
+        if parsed.path == "/health":
+            self._write_json({"status": "ok"})
+            return
+
+        if parsed.path == "/admin/logs":
+            logs = [r.__dict__ for r in self.app_state.snapshot_logs()]
+            self._write_json({"count": len(logs), "logs": logs})
+            return
+
+        if parsed.path == "/admin":
+            self._write_html(self._admin_page())
+            return
+
+        if parsed.path.startswith("/payload/"):
+            self._serve_payload(parsed.path)
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/admin/set-exploit":
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+            return
+
+        if not self._authorized():
+            self.send_error(HTTPStatus.UNAUTHORIZED, "Invalid API token")
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+
+        new_body: str | None = None
+        if "application/json" in content_type:
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+                if isinstance(payload, dict):
+                    value = payload.get("body")
+                    if isinstance(value, str):
+                        new_body = value
+            except json.JSONDecodeError:
+                pass
+        else:
+            values = parse_qs(raw.decode("utf-8"), keep_blank_values=True)
+            body_values = values.get("body")
+            if body_values:
+                new_body = body_values[0]
+
+        if new_body is None:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Missing 'body'")
+            return
+
+        self.app_state.exploit_body = new_body
+        self._write_json({"ok": True, "message": "Exploit body updated"})
+
+    def _authorized(self) -> bool:
+        token = self.headers.get("X-API-Token", "")
+        return secrets.compare_digest(token, self.app_state.api_token)
+
+    def _capture_request(self, parsed: Any) -> None:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body_bytes = self.rfile.read(length) if length > 0 else b""
+        body_text = body_bytes.decode("utf-8", errors="replace")
+        record = RequestRecord(
+            time=datetime.now(timezone.utc).isoformat(),
+            method=self.command,
+            path=parsed.path + (f"?{parsed.query}" if parsed.query else ""),
+            client=self.client_address[0],
+            headers={k: v for k, v in self.headers.items()},
+            body=body_text,
+        )
+        self.app_state.add_log(record)
+
+    def _serve_payload(self, raw_path: str) -> None:
+        relative = unquote(raw_path.removeprefix("/payload/")).strip()
+        payload_root = self.app_state.payload_dir.resolve()
+        candidate = (payload_root / relative).resolve()
+
+        try:
+            candidate.relative_to(payload_root)
+        except ValueError:
+            self.send_error(HTTPStatus.FORBIDDEN, "Path traversal denied")
+            return
+
+        if not candidate.exists() or not candidate.is_file():
+            self.send_error(HTTPStatus.NOT_FOUND, "Payload not found")
+            return
+
+        data = candidate.read_bytes()
+        ctype = "application/octet-stream"
+        if candidate.suffix in {".html", ".htm"}:
+            ctype = "text/html; charset=utf-8"
+        elif candidate.suffix == ".js":
+            ctype = "application/javascript; charset=utf-8"
+        elif candidate.suffix == ".txt":
+            ctype = "text/plain; charset=utf-8"
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _admin_page(self) -> str:
+        token_hint = html.escape(self.app_state.api_token[:6] + "...")
+        return f"""<!doctype html>
+<html>
+  <head><meta charset=\"utf-8\"><title>Exploit Server Admin</title></head>
+  <body>
+    <h1>Exploit Server Admin</h1>
+    <p>Use <code>POST /admin/set-exploit</code> with <code>X-API-Token</code>.</p>
+    <p>Token prefix: <code>{token_hint}</code></p>
+    <p>Check request logs via <a href=\"/admin/logs\">/admin/logs</a>.</p>
+  </body>
+</html>"""
+
+    def _write_json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        data = json.dumps(payload, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _write_html(self, body: str) -> None:
+        data = body.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Keep stdout concise.
+        print(f"[{self.log_date_time_string()}] {self.address_string()} {fmt % args}")
+
+
+def build_default_body() -> str:
+    return """<!doctype html>
+<html>
+  <head><meta charset=\"utf-8\"><title>Exploit Server</title></head>
+  <body>
+    <h1>Exploit Server</h1>
+    <p>This is a configurable lab payload host.</p>
+    <script>
+      // Replace with your authorized test payload.
+      console.log('Exploit server payload loaded');
+    </script>
+  </body>
+</html>"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Burp-like minimal exploit server")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    parser.add_argument(
+        "--payload-dir",
+        default="payloads",
+        help="Directory to serve files from /payload/<name>",
+    )
+    parser.add_argument(
+        "--api-token",
+        default=os.environ.get("EXPLOIT_SERVER_TOKEN") or secrets.token_urlsafe(24),
+        help="Admin API token (or EXPLOIT_SERVER_TOKEN env)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    payload_dir = Path(args.payload_dir)
+    payload_dir.mkdir(parents=True, exist_ok=True)
+
+    state = AppState(
+        exploit_body=build_default_body(),
+        payload_dir=payload_dir,
+        api_token=args.api_token,
+    )
+
+    class Server(ThreadingHTTPServer):
+        app_state: AppState
+
+    server = Server((args.host, args.port), ExploitHandler)
+    server.app_state = state
+
+    print(f"[+] Exploit server listening on http://{args.host}:{args.port}")
+    print("[+] Admin endpoints: /admin, /admin/logs, POST /admin/set-exploit")
+    print(f"[+] API token: {state.api_token}")
+    print(f"[+] Payload directory: {payload_dir.resolve()}")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[+] Shutting down")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/payloads/hello.js
+++ b/payloads/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello from payload file');


### PR DESCRIPTION
### Motivation
- Provide a lightweight, self-contained exploit-server-like tool for authorized security testing labs to host payloads, capture requests, and update exploit content programmatically.

### Description
- Add `exploit_server.py`, a standalone Python HTTP server exposing `GET /` (exploit), `GET /health`, `GET /admin`, `GET /admin/logs`, `GET /payload/<file>`, and `POST /admin/set-exploit` to update the root body.
- Implement bounded in-memory request logging, API token authentication with `X-API-Token`, and safe payload serving with path traversal protection and basic MIME detection.
- Add a `payloads/` directory and sample payload `payloads/hello.js`, and update `README.md` with run instructions and example `curl` workflow.
- Use `ThreadingHTTPServer` and an `AppState` dataclass with a lock to keep server state synchronized.

### Testing
- Successfully compiled the server with `python3 -m py_compile exploit_server.py`.
- Launched the server and validated `GET /health` returned `{"status":"ok"` and `POST /admin/set-exploit` accepted an authenticated JSON payload and returned success.
- Verified that `GET /` reflected the updated exploit body and that `GET /admin/logs` showed captured requests.
- All automated runtime checks described above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31b41b3248331bc90d4d30b65aafd)